### PR TITLE
Add explicit dependency on Unix (xavierleroy#38)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,10 @@
+- #41, #42: fix memory leak when a `Zlib.stream` is finalized and
+  `Zlib.deflate_end` / `Zlib.inflate_end` was not called before
+
 Release 1.11:
 - `Zip.add_entry_generator ~level:0` was missing a CRC update
-- GPR#28: fix build on platforms with no shared libs
-- GPR#33: update META files to use plugin convention
+- #28: fix build on platforms with no shared libs
+- #33: update META files to use plugin convention
 - Use `Stdlib.xxx` instead of `Pervasives.xxx`.  OCaml >= 4.07 is required.
 - `make all` automatically builds in native-code if supported
 - Added local .opam file
@@ -9,29 +12,29 @@ Release 1.11:
 - Generate and install .mli, .cmt, and .cmti files
 
 Release 1.10:
-- GPR#25: Fix Gzip.flush_continue [James Owen]
+- #25: Fix Gzip.flush_continue [James Owen]
 - Improve compatibility with OCaml 4.09
 
 Release 1.09:
-- GPR#22: Add a Gzip.flush_continue function that allows the user to
+- #22: Add a Gzip.flush_continue function that allows the user to
   flush the contents of the zip buffer all the way to disk but then
   continue writing to the zipped channel  [James Owen]
 
 Release 1.08:
-- ocamlfind is now mandatory as a consequence of GPR#4
-- GPR#4: use ocamlfind and $(EXT_...) configuration variables for better
+- ocamlfind is now mandatory as a consequence of #4
+- #4: use ocamlfind and $(EXT_...) configuration variables for better
   cross-platform support in Makefile [user 'whitequark']
 - Improve Mingw support in Makefile (install .dll files) [Bertrand Jeannet]
-- GPR#5: make sure 'zip' and 'camlzip' packages can be used both in the
+- #5: make sure 'zip' and 'camlzip' packages can be used both in the
   same executable [Rudi Grinberg]
-- GPR#6: Z_BUF_ERROR is not a fatal error, just a transient condition
+- #6: Z_BUF_ERROR is not a fatal error, just a transient condition
   [Tuukka Korhonen]
-- GPR#13: fix memory leak in Zlib.compress_direct [Alain Frisch]
-- GPR#14: add Zlib.deflate_string and Zlib.inflate_string, using immutable
+- #13: fix memory leak in Zlib.compress_direct [Alain Frisch]
+- #14: add Zlib.deflate_string and Zlib.inflate_string, using immutable
   strings as input buffers instead of mutable bytes [Vincent Balat]
-- GPR#16: assertion failure when reading ZIP files with 2^16 entries or more
+- #16: assertion failure when reading ZIP files with 2^16 entries or more
   [Einar Lielmanis]
-- GPR#18: in Zip.open_in, properly close channels in case of error
+- #18: in Zip.open_in, properly close channels in case of error
   [Daniel Weil]
 
 Release 1.07:

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ ZLIB_INCLUDE=
 
 ### End of configuration section
 
-OCAMLC=ocamlfind ocamlc -g -safe-string -bin-annot
-OCAMLOPT=ocamlfind ocamlopt -safe-string
+OCAMLC=ocamlfind ocamlc -g -safe-string -bin-annot -package unix
+OCAMLOPT=ocamlfind ocamlopt -safe-string -package unix
 OCAMLDEP=ocamlfind ocamldep
 OCAMLMKLIB=ocamlfind ocamlmklib
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,19 +1,21 @@
 all: test-testzlib test-minizip test-minigzip
 
+OCAMLOPT=ocamlfind ocamlopt -safe-string -package unix -linkpkg
+
 minigzip: ../zip.cmxa minigzip.ml
-	ocamlopt -ccopt -g -g -I .. -o minigzip ../zip.cmxa minigzip.ml
+	$(OCAMLOPT) -ccopt -g -g -I .. -o minigzip ../zip.cmxa minigzip.ml
 
 test-minigzip: minigzip minigzip.run
 	sh ./minigzip.run
 
 minizip: ../zip.cmxa minizip.ml
-	ocamlopt -ccopt -g -g -I .. -o minizip unix.cmxa ../zip.cmxa minizip.ml
+	$(OCAMLOPT) -ccopt -g -g -I .. -o minizip ../zip.cmxa minizip.ml
 
 test-minizip: minizip minizip.run
 	sh ./minizip.run
 
 testzlib: ../zip.cmxa testzlib.ml
-	ocamlopt -g -I .. -o testzlib ../zip.cmxa testzlib.ml
+	$(OCAMLOPT) -g -I .. -o testzlib ../zip.cmxa testzlib.ml
 
 test-testzlib: testzlib testzlib.run
 	sh ./testzlib.run

--- a/test/minizip.ml
+++ b/test/minizip.ml
@@ -28,66 +28,156 @@ let list_entry e =
   if e.Zip.comment <> "" then
     printf "        %s\n" e.Zip.comment
 
-let list zipfile =
-  let ic = Zip.open_in zipfile in
-  if Zip.comment ic <> "" then printf "%s\n" (Zip.comment ic);
-  List.iter list_entry (Zip.entries ic);
-  Zip.close_in ic
+let list (module Impl: Zip.READER) zipfile =
+  let ic = Impl.open_in zipfile in
+  if Impl.comment ic <> "" then printf "%s\n" (Impl.comment ic);
+  List.iter list_entry (Impl.entries ic);
+  Impl.close_in ic
 
-let extract_entry ifile e =
-  print_string e.Zip.filename; print_newline();
-  if e.Zip.is_directory then begin
-    try
-      Unix.mkdir e.Zip.filename 0o777
-    with Unix.Unix_error(Unix.EEXIST, _, _) -> ()
-  end else begin
-    Zip.copy_entry_to_file ifile e e.Zip.filename
-  end
 
-let extract zipfile =
-  let ic = Zip.open_in zipfile in
-  List.iter (extract_entry ic) (Zip.entries ic);
-  Zip.close_in ic
+let extract (module Impl: Zip.READER) zipfile =
+  let ic = Impl.open_in zipfile in
+  let extract_entry e =
+    print_string e.Zip.filename; print_newline();
+    if e.Zip.is_directory then begin
+      try
+        Unix.mkdir e.Zip.filename 0o777
+      with Unix.Unix_error(Unix.EEXIST, _, _) -> ()
+    end else begin
+      Impl.copy_entry_to_file ic e e.Zip.filename
+    end
+  in
+  List.iter extract_entry (Impl.entries ic);
+  Impl.close_in ic
 
-let rec add_entry oc file =
-  let s = Unix.stat file in
-  match s.Unix.st_kind with
-    Unix.S_REG ->
-      printf "Adding file %s\n" file; flush stdout;
-      Zip.copy_file_to_entry file oc ~mtime:s.Unix.st_mtime file
-  | Unix.S_DIR ->
-      printf "Adding directory %s\n" file; flush stdout;
-      Zip.add_entry "" oc ~mtime:s.Unix.st_mtime
-        (if Filename.check_suffix file "/" then file else file ^ "/");
-      let d = Unix.opendir file in
-      begin try
-        while true do
-          let e = Unix.readdir d in
-          if e <> "." && e <> ".." then add_entry oc (Filename.concat file e)
-        done
-      with End_of_file -> ()
-      end;
-      Unix.closedir d
-  | _ -> ()  
+let create (module Impl: Zip.WRITER) zipfile files =
+  let oc = Impl.open_out zipfile in
+  let rec add_entry file =
+    let s = Unix.stat file in
+    match s.Unix.st_kind with
+      Unix.S_REG ->
+        printf "Adding file %s\n" file; flush stdout;
+        Impl.copy_file_to_entry file oc ~mtime:s.Unix.st_mtime file
+    | Unix.S_DIR ->
+        printf "Adding directory %s\n" file; flush stdout;
+        Impl.add_entry "" oc ~mtime:s.Unix.st_mtime
+          (if Filename.check_suffix file "/" then file else file ^ "/");
+        let d = Unix.opendir file in
+        begin try
+          while true do
+            let e = Unix.readdir d in
+            if e <> "." && e <> ".." then add_entry (Filename.concat file e)
+          done
+        with End_of_file -> ()
+        end;
+        Unix.closedir d
+    | _ -> ()
+  in
+  Array.iter add_entry files;
+  Impl.close_out oc
 
-let create zipfile files =
-  let oc = Zip.open_out zipfile in
-  Array.iter (add_entry oc) files;
-  Zip.close_out oc
+(* Read the whole file to memory first, then read from memory *)
+module Zip_mem_reader = Zip.Make_reader(struct
+  type t = {
+    mutable ptr: int;
+    buf : Buffer.t;
+  }
+
+  let open_in filename =
+    let buf = Buffer.create 256 in
+    let ic = open_in filename in
+    let rec loop () =
+      try
+        Buffer.add_channel buf ic 128;
+        loop ()
+      with End_of_file ->
+        close_in ic
+    in
+    loop ();
+    { buf; ptr = 0 }
+
+  let close_in _ = ()
+
+  let input_byte t =
+    if t.ptr >= Buffer.length t.buf
+    then raise End_of_file
+    else begin
+      let c = Buffer.nth t.buf t.ptr in
+      t.ptr <- t.ptr + 1;
+      Char.code c
+    end
+
+  let input t dst ofs len =
+    if ofs < 0 || len < 0 || ofs > Bytes.length dst - len
+    then invalid_arg "input"
+    else begin
+      let len = min (Buffer.length t.buf - ofs) len in
+      if len >= 0 then begin
+        Buffer.blit t.buf t.ptr dst ofs len;
+        t.ptr <- t.ptr + len;
+        len
+      end
+      else 0
+    end
+
+  let really_input t dst ofs len =
+    let input_len = input t dst ofs len in
+    if input_len <> len
+    then raise End_of_file
+    else ()
+
+  let length t = Int64.of_int (Buffer.length t.buf)
+  let pos t = Int64.of_int t.ptr
+  let seek t pos = t.ptr <- Int64.to_int pos
+end)
+
+(* Make all writes in memory, dumping to a file at the very end *)
+module Zip_mem_writer = Zip.Make_writer(struct
+  type t = {
+    filename: string;
+    buf: Buffer.t;
+  }
+
+  let open_out filename = { filename; buf = Buffer.create 10 }
+
+  let close_out { filename;  buf } =
+    let oc = Stdlib.open_out_bin filename in
+    Stdlib.output_string oc (Buffer.contents buf);
+    Stdlib.close_out oc
+
+  let output_byte { buf; _} code =
+    Buffer.add_char buf (Char.chr ((code mod 256 + 256) mod 256))
+
+  let output_string { buf; _ } = Buffer.add_string buf
+  let output_substring { buf; _ } = Buffer.add_substring buf
+  let output { buf; _ } = Buffer.add_subbytes buf
+  let pos { buf; _ } = Int64.of_int (Buffer.length buf)
+end)
+
 
 let usage() =
   prerr_string
-"Usage: 
-  minizip t <zipfile>           show contents of <zipfile>
-  minizip x <zipfile>           extract files from <zipfile>
-  minizip c <zipfile> <file> .. create a <zipfile> with the given files\n";
+"Usage:
+  minizip t [-b] <zipfile>           show contents of <zipfile>
+  minizip x [-b] <zipfile>           extract files from <zipfile>
+  minizip c [-b] <zipfile> <file> .. create a <zipfile> with the given files
+
+    -b Use in-memory buffer for read/write operations (testing functors) \n";
+
   exit 2
 
 let _ =
   if Array.length Sys.argv < 3 then usage();
+  let zipfile, (module Reader: Zip.READER), (module Writer: Zip.WRITER) =
+    match Sys.argv.(2) with
+    | "-b" ->
+      if Array.length Sys.argv < 4 then usage();
+      3, (module Zip_mem_reader), (module Zip_mem_writer)
+    | _ -> 2, (module Zip), (module Zip)
+  in
   match Sys.argv.(1) with
-    "t" -> list Sys.argv.(2)
-  | "x" -> extract Sys.argv.(2)
-  | "c" -> create Sys.argv.(2)
-                  (Array.sub Sys.argv 3 (Array.length Sys.argv - 3))
+    "t" -> list (module Reader) Sys.argv.(zipfile)
+  | "x" -> extract (module Reader) Sys.argv.(zipfile)
+  | "c" -> create (module Writer) Sys.argv.(zipfile)
+                  (Array.sub Sys.argv (zipfile + 1) (Array.length Sys.argv - zipfile - 1))
   | _ -> usage()

--- a/test/minizip.run
+++ b/test/minizip.run
@@ -19,5 +19,6 @@ runtest() {
 runtest "Zip 1" "$here/minizip c" "$here/minizip x"
 runtest "Zip 2" "zip -r" "$here/minizip x"
 runtest "Zip 3" "$here/minizip c" "unzip"
-
-
+runtest "Zip 4 (in-memory)" "$here/minizip c -b" "$here/minizip x -b"
+runtest "Zip 5 (in-memory)" "zip -r" "$here/minizip x -b"
+runtest "Zip 6 (in-memory)" "$here/minizip c -b" "unzip"

--- a/zip.ml
+++ b/zip.ml
@@ -95,308 +95,308 @@ end
 
 module Make_reader(In_channel: IN_CHANNEL) : READER = struct
 
-let read1 = In_channel.input_byte
-let read2 ic =
-  let lb = read1 ic in let hb = read1 ic in lb lor (hb lsl 8)
-let read4 ic =
-  let lw = read2 ic in let hw = read2 ic in
-  Int32.logor (Int32.of_int lw) (Int32.shift_left (Int32.of_int hw) 16)
-let read4_int ic =
-  let lw = read2 ic in let hw = read2 ic in
-  if hw > max_int lsr 16 then raise (Error("", "", "32-bit data too large"));
-  lw lor (hw lsl 16)
-let readstring ic n =
-  let s = Bytes.create n in
-  In_channel.really_input ic s 0 n; Bytes.unsafe_to_string s
+  let read1 = In_channel.input_byte
+  let read2 ic =
+    let lb = read1 ic in let hb = read1 ic in lb lor (hb lsl 8)
+  let read4 ic =
+    let lw = read2 ic in let hw = read2 ic in
+    Int32.logor (Int32.of_int lw) (Int32.shift_left (Int32.of_int hw) 16)
+  let read4_int ic =
+    let lw = read2 ic in let hw = read2 ic in
+    if hw > max_int lsr 16 then raise (Error("", "", "32-bit data too large"));
+    lw lor (hw lsl 16)
+  let readstring ic n =
+    let s = Bytes.create n in
+    In_channel.really_input ic s 0 n; Bytes.unsafe_to_string s
 
-type in_file =
-  { if_filename: string;
-    if_channel: In_channel.t;
-    if_entries: entry list;
-    if_directory: (string, entry) Hashtbl.t;
-    if_comment: string }
+  type in_file =
+    { if_filename: string;
+      if_channel: In_channel.t;
+      if_entries: entry list;
+      if_directory: (string, entry) Hashtbl.t;
+      if_comment: string }
 
-let entries ifile = ifile.if_entries
-let comment ifile = ifile.if_comment
+  let entries ifile = ifile.if_entries
+  let comment ifile = ifile.if_comment
 
-(* Return the position of the last occurrence of [pattern] in [buf],
-   or -1 if not found. *)
+  (* Return the position of the last occurrence of [pattern] in [buf],
+     or -1 if not found. *)
 
-let strrstr (pattern: string) (buf: bytes) ofs len =
-  let rec search i j =
-    if i < ofs then -1
-    else if j >= String.length pattern then i
-    else if String.get pattern j = Bytes.get buf (i + j) then search i (j+1)
-    else search (i-1) 0
-  in search (ofs + len - String.length pattern) 0
+  let strrstr (pattern: string) (buf: bytes) ofs len =
+    let rec search i j =
+      if i < ofs then -1
+      else if j >= String.length pattern then i
+      else if String.get pattern j = Bytes.get buf (i + j) then search i (j+1)
+      else search (i-1) 0
+    in search (ofs + len - String.length pattern) 0
 
-(* Convert between Unix dates and DOS dates *)
+  (* Convert between Unix dates and DOS dates *)
 
-let unixtime_of_dostime time date =
-  fst(Unix.mktime
-        { Unix.tm_sec = (time lsl 1) land 0x3e;
-          Unix.tm_min = (time lsr 5) land 0x3f;
-          Unix.tm_hour = (time lsr 11) land 0x1f;
-          Unix.tm_mday = date land 0x1f;
-          Unix.tm_mon = ((date lsr 5) land 0xf) - 1;
-          Unix.tm_year = ((date lsr 9) land 0x7f) + 80;
-          Unix.tm_wday = 0;
-          Unix.tm_yday = 0;
-          Unix.tm_isdst = false })
+  let unixtime_of_dostime time date =
+    fst(Unix.mktime
+          { Unix.tm_sec = (time lsl 1) land 0x3e;
+            Unix.tm_min = (time lsr 5) land 0x3f;
+            Unix.tm_hour = (time lsr 11) land 0x1f;
+            Unix.tm_mday = date land 0x1f;
+            Unix.tm_mon = ((date lsr 5) land 0xf) - 1;
+            Unix.tm_year = ((date lsr 9) land 0x7f) + 80;
+            Unix.tm_wday = 0;
+            Unix.tm_yday = 0;
+            Unix.tm_isdst = false })
 
-(* Read end of central directory record *)
+  (* Read end of central directory record *)
 
-let read_ecd filename ic =
-  let buf = Bytes.create 256 in
-  let filelen = In_channel.length ic in
-  let rec find_ecd pos len =
-    (* On input, bytes 0 ... len - 1 of buf reflect what is at pos in ic *)
-    if pos <= 0L || Int64.sub filelen pos >= 0x10000L then
-      raise (Error(filename, "",
-                   "end of central directory not found, not a ZIP file"));
-    let toread = if pos >= 128L then 128 else Int64.to_int pos in
-    (* Make room for "toread" extra bytes, and read them *)
-    Bytes.blit buf 0 buf toread (256 - toread);
-    let newpos = Int64.(sub pos (of_int toread)) in
-    In_channel.seek ic newpos;
-    In_channel.really_input ic buf 0 toread;
-    let newlen = min (toread + len) 256 in
-    (* Search for magic number *)
-    let ofs = strrstr "PK\005\006" buf 0 newlen in
-    if ofs < 0 || newlen < 22 ||
-       (let comment_len =
-              (Char.code (Bytes.get buf (ofs + 20)))
-          lor ((Char.code (Bytes.get buf (ofs + 21))) lsl 8) in
-        Int64.(add newpos (of_int (ofs + 22 + comment_len))) <> filelen) then
-      find_ecd newpos newlen
-    else
-      Int64.(add newpos (of_int ofs)) in
-  In_channel.seek ic (find_ecd filelen 0);
-  let magic = read4 ic in
-  let disk_no = read2 ic in
-  let cd_disk_no = read2 ic in
-  let _disk_entries = read2 ic in
-  let cd_entries = read2 ic in
-  let cd_size = read4 ic in
-  let cd_offset = read4 ic in
-  let comment_len = read2 ic in
-  let comment = readstring ic comment_len in
-  assert (magic = Int32.of_int 0x06054b50);
-  if disk_no <> 0 || cd_disk_no <> 0 then
-    raise (Error(filename, "", "multi-disk ZIP files not supported"));
-  (cd_entries, cd_size, cd_offset, comment)
-
-(* Read central directory *)
-
-let int64_of_uint32 n =
-  Int64.(logand (of_int32 n) 0xFFFF_FFFFL)
-
-let read_cd filename ic cd_entries cd_offset cd_bound =
-  let cd_bound = int64_of_uint32 cd_bound in
-  try
-    In_channel.seek ic (int64_of_uint32 cd_offset);
-    let e = ref [] in
-    let entrycnt = ref 0 in
-    while (In_channel.pos ic < cd_bound) do
-      incr entrycnt;
-      let magic = read4 ic in
-      let _version_made_by = read2 ic in
-      let _version_needed = read2 ic in
-      let flags = read2 ic in
-      let methd = read2 ic in
-      let lastmod_time = read2 ic in
-      let lastmod_date = read2 ic in
-      let crc = read4 ic in
-      let compr_size = read4_int ic in
-      let uncompr_size = read4_int ic in
-      let name_len = read2 ic in
-      let extra_len = read2 ic in
-      let comment_len = read2 ic in
-      let _disk_number = read2 ic in
-      let _internal_attr = read2 ic in
-      let _external_attr = read4 ic in
-      let header_offset = int64_of_uint32 (read4 ic) in
-      let name = readstring ic name_len in
-      let extra = readstring ic extra_len in
-      let comment = readstring ic comment_len in
-      if magic <> Int32.of_int 0x02014b50 then
-        raise (Error(filename, name,
-                     "wrong file header in central directory"));
-      if flags land 1 <> 0 then
-        raise (Error(filename, name, "encrypted entries not supported"));
-
-      e := { filename = name;
-             extra = extra;
-             comment = comment;
-             methd = (match methd with
-                         0 -> Stored
-                       | 8 -> Deflated
-                       | _ -> raise (Error(filename, name,
-                                           "unknown compression method")));
-             mtime = unixtime_of_dostime lastmod_time lastmod_date;
-             crc = crc;
-             uncompressed_size = uncompr_size;
-             compressed_size = compr_size;
-             is_directory = filename_is_directory name;
-             file_offset = header_offset
-           } :: !e
-    done;
-    assert((cd_bound = (In_channel.pos ic)) &&
-           (cd_entries = 65535 || cd_entries = !entrycnt land 0xffff));
-    List.rev !e
-  with End_of_file ->
-    raise (Error(filename, "", "end-of-file while reading central directory"))
-
-(* Open a ZIP file for reading *)
-
-let open_in filename =
-  let ic = In_channel.open_in filename in
-  try
-    let (cd_entries, cd_size, cd_offset, cd_comment) = read_ecd filename ic in
-    let entries =
-      read_cd filename ic cd_entries cd_offset (Int32.add cd_offset cd_size) in
-    let dir = Hashtbl.create (cd_entries / 3) in
-    List.iter (fun e -> Hashtbl.add dir e.filename e) entries;
-    { if_filename = filename;
-      if_channel = ic;
-      if_entries = entries;
-      if_directory = dir;
-      if_comment = cd_comment }
-  with exn ->
-    In_channel.close_in ic; raise exn
-
-(* Close a ZIP file opened for reading *)
-
-let close_in ifile =
-  In_channel.close_in ifile.if_channel
-
-(* Return the info associated with an entry *)
-
-let find_entry ifile name =
-  Hashtbl.find ifile.if_directory name
-
-(* Position on an entry *)
-
-let goto_entry ifile e =
-  try
-    let ic = ifile.if_channel in
-    In_channel.seek ic e.file_offset;
+  let read_ecd filename ic =
+    let buf = Bytes.create 256 in
+    let filelen = In_channel.length ic in
+    let rec find_ecd pos len =
+      (* On input, bytes 0 ... len - 1 of buf reflect what is at pos in ic *)
+      if pos <= 0L || Int64.sub filelen pos >= 0x10000L then
+        raise (Error(filename, "",
+                     "end of central directory not found, not a ZIP file"));
+      let toread = if pos >= 128L then 128 else Int64.to_int pos in
+      (* Make room for "toread" extra bytes, and read them *)
+      Bytes.blit buf 0 buf toread (256 - toread);
+      let newpos = Int64.(sub pos (of_int toread)) in
+      In_channel.seek ic newpos;
+      In_channel.really_input ic buf 0 toread;
+      let newlen = min (toread + len) 256 in
+      (* Search for magic number *)
+      let ofs = strrstr "PK\005\006" buf 0 newlen in
+      if ofs < 0 || newlen < 22 ||
+         (let comment_len =
+                (Char.code (Bytes.get buf (ofs + 20)))
+            lor ((Char.code (Bytes.get buf (ofs + 21))) lsl 8) in
+          Int64.(add newpos (of_int (ofs + 22 + comment_len))) <> filelen) then
+        find_ecd newpos newlen
+      else
+        Int64.(add newpos (of_int ofs)) in
+    In_channel.seek ic (find_ecd filelen 0);
     let magic = read4 ic in
-    let _version_needed = read2 ic in
-    let _flags = read2 ic in
-    let _methd = read2 ic in
-    let _lastmod_time = read2 ic in
-    let _lastmod_date = read2 ic in
-    let _crc = read4 ic in
-    let _compr_size = read4_int ic in
-    let _uncompr_size = read4_int ic in
-    let filename_len = read2 ic in
-    let extra_len = read2 ic in
-    if magic <> Int32.of_int 0x04034b50 then
-       raise (Error(ifile.if_filename, e.filename, "wrong local file header"));
-    (* Could validate information read against directory entry, but
-       what the heck *)
-    In_channel.seek ifile.if_channel
-      (Int64.add e.file_offset (Int64.of_int (30 + filename_len + extra_len)))
-  with End_of_file ->
-    raise (Error(ifile.if_filename, e.filename, "truncated local file header"))
+    let disk_no = read2 ic in
+    let cd_disk_no = read2 ic in
+    let _disk_entries = read2 ic in
+    let cd_entries = read2 ic in
+    let cd_size = read4 ic in
+    let cd_offset = read4 ic in
+    let comment_len = read2 ic in
+    let comment = readstring ic comment_len in
+    assert (magic = Int32.of_int 0x06054b50);
+    if disk_no <> 0 || cd_disk_no <> 0 then
+      raise (Error(filename, "", "multi-disk ZIP files not supported"));
+    (cd_entries, cd_size, cd_offset, comment)
 
-(* Read the contents of an entry as a string *)
+  (* Read central directory *)
 
-let read_entry ifile e =
-  try
-    goto_entry ifile e;
-    let res = Bytes.create e.uncompressed_size in
-    match e.methd with
-      Stored ->
-        if e.compressed_size <> e.uncompressed_size then
-          raise (Error(ifile.if_filename, e.filename,
-                       "wrong size for stored entry"));
-        In_channel.really_input ifile.if_channel res 0 e.uncompressed_size;
-        Bytes.unsafe_to_string res
-    | Deflated ->
-        let in_avail = ref e.compressed_size in
-        let out_pos = ref 0 in
-        begin try
-          Zlib.uncompress ~header:false
-            (fun buf ->
-              let read = In_channel.input ifile.if_channel buf 0
-                               (min !in_avail (Bytes.length buf)) in
-              in_avail := !in_avail - read;
-              read)
-            (fun buf len ->
-              if !out_pos + len > Bytes.length res then
-                raise (Error(ifile.if_filename, e.filename,
-                             "wrong size for deflated entry (too much data)"));
-              Bytes.blit buf 0 res !out_pos len;
-              out_pos := !out_pos + len)
-        with Zlib.Error(_, _) ->
-          raise (Error(ifile.if_filename, e.filename, "decompression error"))
-        end;
-        if !out_pos <> Bytes.length res then
-          raise (Error(ifile.if_filename, e.filename,
-                       "wrong size for deflated entry (not enough data)"));
-        let crc = Zlib.update_crc Int32.zero res 0 (Bytes.length res) in
-        if crc <> e.crc then
-          raise (Error(ifile.if_filename, e.filename, "CRC mismatch"));
-        Bytes.unsafe_to_string res
-  with End_of_file ->
-    raise (Error(ifile.if_filename, e.filename, "truncated data"))
+  let int64_of_uint32 n =
+    Int64.(logand (of_int32 n) 0xFFFF_FFFFL)
 
-(* Write the contents of an entry into an out channel *)
+  let read_cd filename ic cd_entries cd_offset cd_bound =
+    let cd_bound = int64_of_uint32 cd_bound in
+    try
+      In_channel.seek ic (int64_of_uint32 cd_offset);
+      let e = ref [] in
+      let entrycnt = ref 0 in
+      while (In_channel.pos ic < cd_bound) do
+        incr entrycnt;
+        let magic = read4 ic in
+        let _version_made_by = read2 ic in
+        let _version_needed = read2 ic in
+        let flags = read2 ic in
+        let methd = read2 ic in
+        let lastmod_time = read2 ic in
+        let lastmod_date = read2 ic in
+        let crc = read4 ic in
+        let compr_size = read4_int ic in
+        let uncompr_size = read4_int ic in
+        let name_len = read2 ic in
+        let extra_len = read2 ic in
+        let comment_len = read2 ic in
+        let _disk_number = read2 ic in
+        let _internal_attr = read2 ic in
+        let _external_attr = read4 ic in
+        let header_offset = int64_of_uint32 (read4 ic) in
+        let name = readstring ic name_len in
+        let extra = readstring ic extra_len in
+        let comment = readstring ic comment_len in
+        if magic <> Int32.of_int 0x02014b50 then
+          raise (Error(filename, name,
+                       "wrong file header in central directory"));
+        if flags land 1 <> 0 then
+          raise (Error(filename, name, "encrypted entries not supported"));
 
-let copy_entry_to_channel ifile e oc =
-  try
-    goto_entry ifile e;
-    match e.methd with
-      Stored ->
-        if e.compressed_size <> e.uncompressed_size then
-          raise (Error(ifile.if_filename, e.filename,
-                       "wrong size for stored entry"));
-        let buf = Bytes.create 4096 in
-        let rec copy n =
-          if n > 0 then begin
-            let r = In_channel.input ifile.if_channel buf 0 (min n (Bytes.length buf)) in
-            output oc buf 0 r;
-            copy (n - r)
-          end in
-        copy e.uncompressed_size
-    | Deflated ->
-        let in_avail = ref e.compressed_size in
-        let crc = ref Int32.zero in
-        begin try
-          Zlib.uncompress ~header:false
-            (fun buf ->
-              let read = In_channel.input ifile.if_channel buf 0
-                               (min !in_avail (Bytes.length buf)) in
-              in_avail := !in_avail - read;
-              read)
-            (fun buf len ->
-              output oc buf 0 len;
-              crc := Zlib.update_crc !crc buf 0 len)
-        with Zlib.Error(_, _) ->
-          raise (Error(ifile.if_filename, e.filename, "decompression error"))
-        end;
-        if !crc <> e.crc then
-          raise (Error(ifile.if_filename, e.filename, "CRC mismatch"))
-  with End_of_file ->
-    raise (Error(ifile.if_filename, e.filename, "truncated data"))
+        e := { filename = name;
+               extra = extra;
+               comment = comment;
+               methd = (match methd with
+                           0 -> Stored
+                         | 8 -> Deflated
+                         | _ -> raise (Error(filename, name,
+                                             "unknown compression method")));
+               mtime = unixtime_of_dostime lastmod_time lastmod_date;
+               crc = crc;
+               uncompressed_size = uncompr_size;
+               compressed_size = compr_size;
+               is_directory = filename_is_directory name;
+               file_offset = header_offset
+             } :: !e
+      done;
+      assert((cd_bound = (In_channel.pos ic)) &&
+             (cd_entries = 65535 || cd_entries = !entrycnt land 0xffff));
+      List.rev !e
+    with End_of_file ->
+      raise (Error(filename, "", "end-of-file while reading central directory"))
 
-(* Write the contents of an entry to a file *)
+  (* Open a ZIP file for reading *)
 
-let copy_entry_to_file ifile e outfilename =
-  let oc = open_out_bin outfilename in
-  try
-    copy_entry_to_channel ifile e oc;
-    close_out oc;
-    begin try
-      Unix.utimes outfilename e.mtime e.mtime
-    with Unix.Unix_error(_, _, _) | Invalid_argument _ -> ()
-    end
-  with x ->
-    close_out oc;
-    Sys.remove outfilename;
-    raise x
+  let open_in filename =
+    let ic = In_channel.open_in filename in
+    try
+      let (cd_entries, cd_size, cd_offset, cd_comment) = read_ecd filename ic in
+      let entries =
+        read_cd filename ic cd_entries cd_offset (Int32.add cd_offset cd_size) in
+      let dir = Hashtbl.create (cd_entries / 3) in
+      List.iter (fun e -> Hashtbl.add dir e.filename e) entries;
+      { if_filename = filename;
+        if_channel = ic;
+        if_entries = entries;
+        if_directory = dir;
+        if_comment = cd_comment }
+    with exn ->
+      In_channel.close_in ic; raise exn
+
+  (* Close a ZIP file opened for reading *)
+
+  let close_in ifile =
+    In_channel.close_in ifile.if_channel
+
+  (* Return the info associated with an entry *)
+
+  let find_entry ifile name =
+    Hashtbl.find ifile.if_directory name
+
+  (* Position on an entry *)
+
+  let goto_entry ifile e =
+    try
+      let ic = ifile.if_channel in
+      In_channel.seek ic e.file_offset;
+      let magic = read4 ic in
+      let _version_needed = read2 ic in
+      let _flags = read2 ic in
+      let _methd = read2 ic in
+      let _lastmod_time = read2 ic in
+      let _lastmod_date = read2 ic in
+      let _crc = read4 ic in
+      let _compr_size = read4_int ic in
+      let _uncompr_size = read4_int ic in
+      let filename_len = read2 ic in
+      let extra_len = read2 ic in
+      if magic <> Int32.of_int 0x04034b50 then
+         raise (Error(ifile.if_filename, e.filename, "wrong local file header"));
+      (* Could validate information read against directory entry, but
+         what the heck *)
+      In_channel.seek ifile.if_channel
+        (Int64.add e.file_offset (Int64.of_int (30 + filename_len + extra_len)))
+    with End_of_file ->
+      raise (Error(ifile.if_filename, e.filename, "truncated local file header"))
+
+  (* Read the contents of an entry as a string *)
+
+  let read_entry ifile e =
+    try
+      goto_entry ifile e;
+      let res = Bytes.create e.uncompressed_size in
+      match e.methd with
+        Stored ->
+          if e.compressed_size <> e.uncompressed_size then
+            raise (Error(ifile.if_filename, e.filename,
+                         "wrong size for stored entry"));
+          In_channel.really_input ifile.if_channel res 0 e.uncompressed_size;
+          Bytes.unsafe_to_string res
+      | Deflated ->
+          let in_avail = ref e.compressed_size in
+          let out_pos = ref 0 in
+          begin try
+            Zlib.uncompress ~header:false
+              (fun buf ->
+                let read = In_channel.input ifile.if_channel buf 0
+                                 (min !in_avail (Bytes.length buf)) in
+                in_avail := !in_avail - read;
+                read)
+              (fun buf len ->
+                if !out_pos + len > Bytes.length res then
+                  raise (Error(ifile.if_filename, e.filename,
+                               "wrong size for deflated entry (too much data)"));
+                Bytes.blit buf 0 res !out_pos len;
+                out_pos := !out_pos + len)
+          with Zlib.Error(_, _) ->
+            raise (Error(ifile.if_filename, e.filename, "decompression error"))
+          end;
+          if !out_pos <> Bytes.length res then
+            raise (Error(ifile.if_filename, e.filename,
+                         "wrong size for deflated entry (not enough data)"));
+          let crc = Zlib.update_crc Int32.zero res 0 (Bytes.length res) in
+          if crc <> e.crc then
+            raise (Error(ifile.if_filename, e.filename, "CRC mismatch"));
+          Bytes.unsafe_to_string res
+    with End_of_file ->
+      raise (Error(ifile.if_filename, e.filename, "truncated data"))
+
+  (* Write the contents of an entry into an out channel *)
+
+  let copy_entry_to_channel ifile e oc =
+    try
+      goto_entry ifile e;
+      match e.methd with
+        Stored ->
+          if e.compressed_size <> e.uncompressed_size then
+            raise (Error(ifile.if_filename, e.filename,
+                         "wrong size for stored entry"));
+          let buf = Bytes.create 4096 in
+          let rec copy n =
+            if n > 0 then begin
+              let r = In_channel.input ifile.if_channel buf 0 (min n (Bytes.length buf)) in
+              output oc buf 0 r;
+              copy (n - r)
+            end in
+          copy e.uncompressed_size
+      | Deflated ->
+          let in_avail = ref e.compressed_size in
+          let crc = ref Int32.zero in
+          begin try
+            Zlib.uncompress ~header:false
+              (fun buf ->
+                let read = In_channel.input ifile.if_channel buf 0
+                                 (min !in_avail (Bytes.length buf)) in
+                in_avail := !in_avail - read;
+                read)
+              (fun buf len ->
+                output oc buf 0 len;
+                crc := Zlib.update_crc !crc buf 0 len)
+          with Zlib.Error(_, _) ->
+            raise (Error(ifile.if_filename, e.filename, "decompression error"))
+          end;
+          if !crc <> e.crc then
+            raise (Error(ifile.if_filename, e.filename, "CRC mismatch"))
+    with End_of_file ->
+      raise (Error(ifile.if_filename, e.filename, "truncated data"))
+
+  (* Write the contents of an entry to a file *)
+
+  let copy_entry_to_file ifile e outfilename =
+    let oc = open_out_bin outfilename in
+    try
+      copy_entry_to_channel ifile e oc;
+      close_out oc;
+      begin try
+        Unix.utimes outfilename e.mtime e.mtime
+      with Unix.Unix_error(_, _, _) | Invalid_argument _ -> ()
+      end
+    with x ->
+      close_out oc;
+      Sys.remove outfilename;
+      raise x
 end
 
 include Make_reader(struct
@@ -414,280 +414,280 @@ end)
 
 module Make_writer(Out_channel: OUT_CHANNEL) : WRITER = struct
 
-let write1 = Out_channel.output_byte
-let write2 oc n =
-  write1 oc n; write1 oc (n lsr 8)
-let write4 oc n =
-  write2 oc (Int32.to_int n);
-  write2 oc (Int32.to_int (Int32.shift_right_logical n 16))
-let write4_int oc n =
-  write2 oc n;
-  write2 oc (n lsr 16)
-let writestring oc s =
-  Out_channel.output_string oc s
+  let write1 = Out_channel.output_byte
+  let write2 oc n =
+    write1 oc n; write1 oc (n lsr 8)
+  let write4 oc n =
+    write2 oc (Int32.to_int n);
+    write2 oc (Int32.to_int (Int32.shift_right_logical n 16))
+  let write4_int oc n =
+    write2 oc n;
+    write2 oc (n lsr 16)
+  let writestring oc s =
+    Out_channel.output_string oc s
 
-type out_file =
-  { of_filename: string;
-    of_channel: Out_channel.t;
-    mutable of_entries: entry list;
-    of_comment: string }
+  type out_file =
+    { of_filename: string;
+      of_channel: Out_channel.t;
+      mutable of_entries: entry list;
+      of_comment: string }
 
-(* Open a ZIP file for writing *)
+  (* Open a ZIP file for writing *)
 
-let open_out ?(comment = "") filename =
-  if String.length comment >= 0x10000 then
-    raise(Error(filename, "", "comment too long"));
-  { of_filename = filename;
-    of_channel = Out_channel.open_out filename;
-    of_entries = [];
-    of_comment = comment }
+  let open_out ?(comment = "") filename =
+    if String.length comment >= 0x10000 then
+      raise(Error(filename, "", "comment too long"));
+    { of_filename = filename;
+      of_channel = Out_channel.open_out filename;
+      of_entries = [];
+      of_comment = comment }
 
-(* Close a ZIP file for writing.  Add central directory. *)
-let dostime_of_unixtime t =
-  let tm = Unix.localtime t in
-  (tm.Unix.tm_sec lsr 1
-     + (tm.Unix.tm_min lsl 5)
-     + (tm.Unix.tm_hour lsl 11),
-   tm.Unix.tm_mday
-     + (tm.Unix.tm_mon + 1) lsl 5
-     + (tm.Unix.tm_year - 80) lsl 9)
+  (* Close a ZIP file for writing.  Add central directory. *)
+  let dostime_of_unixtime t =
+    let tm = Unix.localtime t in
+    (tm.Unix.tm_sec lsr 1
+       + (tm.Unix.tm_min lsl 5)
+       + (tm.Unix.tm_hour lsl 11),
+     tm.Unix.tm_mday
+       + (tm.Unix.tm_mon + 1) lsl 5
+       + (tm.Unix.tm_year - 80) lsl 9)
 
-let write_directory_entry oc e =
-  write4 oc (Int32.of_int 0x02014b50);  (* signature *)
-  let version = match e.methd with Stored -> 10 | Deflated -> 20 in
-  write2 oc version;                    (* version made by *)
-  write2 oc version;                    (* version needed to extract *)
-  write2 oc 8;                          (* flags *)
-  write2 oc (match e.methd with Stored -> 0 | Deflated -> 8); (* method *)
-  let (time, date) = dostime_of_unixtime e.mtime in
-  write2 oc time;                       (* last mod time *)
-  write2 oc date;                       (* last mod date *)
-  write4 oc e.crc;                      (* CRC32 *)
-  write4_int oc e.compressed_size;      (* compressed size *)
-  write4_int oc e.uncompressed_size;    (* uncompressed size *)
-  write2 oc (String.length e.filename); (* filename length *)
-  write2 oc (String.length e.extra);    (* extra length *)
-  write2 oc (String.length e.comment);  (* comment length *)
-  write2 oc 0;                          (* disk number start *)
-  write2 oc 0;                          (* internal attributes *)
-  write4_int oc 0;                      (* external attributes *)
-  write4 oc (Int64.to_int32 e.file_offset); (* offset of local header *)
-  writestring oc e.filename;            (* filename *)
-  writestring oc e.extra;               (* extra info *)
-  writestring oc e.comment              (* file comment *)
+  let write_directory_entry oc e =
+    write4 oc (Int32.of_int 0x02014b50);  (* signature *)
+    let version = match e.methd with Stored -> 10 | Deflated -> 20 in
+    write2 oc version;                    (* version made by *)
+    write2 oc version;                    (* version needed to extract *)
+    write2 oc 8;                          (* flags *)
+    write2 oc (match e.methd with Stored -> 0 | Deflated -> 8); (* method *)
+    let (time, date) = dostime_of_unixtime e.mtime in
+    write2 oc time;                       (* last mod time *)
+    write2 oc date;                       (* last mod date *)
+    write4 oc e.crc;                      (* CRC32 *)
+    write4_int oc e.compressed_size;      (* compressed size *)
+    write4_int oc e.uncompressed_size;    (* uncompressed size *)
+    write2 oc (String.length e.filename); (* filename length *)
+    write2 oc (String.length e.extra);    (* extra length *)
+    write2 oc (String.length e.comment);  (* comment length *)
+    write2 oc 0;                          (* disk number start *)
+    write2 oc 0;                          (* internal attributes *)
+    write4_int oc 0;                      (* external attributes *)
+    write4 oc (Int64.to_int32 e.file_offset); (* offset of local header *)
+    writestring oc e.filename;            (* filename *)
+    writestring oc e.extra;               (* extra info *)
+    writestring oc e.comment              (* file comment *)
 
-let close_out ofile =
-  let oc = ofile.of_channel in
-  let pos_out oc = Int64.to_int (Out_channel.pos oc) in
-  let start_cd = pos_out oc in
-  List.iter (write_directory_entry oc) (List.rev ofile.of_entries);
-  let cd_size = pos_out oc - start_cd in
-  let num_entries = List.length ofile.of_entries in
-  if num_entries >= 0x10000 then
-    raise(Error(ofile.of_filename, "", "too many entries"));
-  write4 oc (Int32.of_int 0x06054b50);  (* signature *)
-  write2 oc 0;                          (* disk number *)
-  write2 oc 0;                          (* number of disk with central dir *)
-  write2 oc num_entries;                (* # entries in this disk *)
-  write2 oc num_entries;                (* # entries in central dir *)
-  write4_int oc cd_size;                (* size of central dir *)
-  write4_int oc start_cd;               (* offset of central dir *)
-  write2 oc (String.length ofile.of_comment); (* length of comment *)
-  writestring oc ofile.of_comment;         (* comment *)
-  Out_channel.close_out oc
+  let close_out ofile =
+    let oc = ofile.of_channel in
+    let pos_out oc = Int64.to_int (Out_channel.pos oc) in
+    let start_cd = pos_out oc in
+    List.iter (write_directory_entry oc) (List.rev ofile.of_entries);
+    let cd_size = pos_out oc - start_cd in
+    let num_entries = List.length ofile.of_entries in
+    if num_entries >= 0x10000 then
+      raise(Error(ofile.of_filename, "", "too many entries"));
+    write4 oc (Int32.of_int 0x06054b50);  (* signature *)
+    write2 oc 0;                          (* disk number *)
+    write2 oc 0;                          (* number of disk with central dir *)
+    write2 oc num_entries;                (* # entries in this disk *)
+    write2 oc num_entries;                (* # entries in central dir *)
+    write4_int oc cd_size;                (* size of central dir *)
+    write4_int oc start_cd;               (* offset of central dir *)
+    write2 oc (String.length ofile.of_comment); (* length of comment *)
+    writestring oc ofile.of_comment;         (* comment *)
+    Out_channel.close_out oc
 
-(* Write a local file header and return the corresponding entry *)
+  (* Write a local file header and return the corresponding entry *)
 
-let add_entry_header ofile extra comment level mtime filename =
-  if level < 0 || level > 9 then
-    raise(Error(ofile.of_filename, filename, "wrong compression level"));
-  if String.length filename >= 0x10000 then
-    raise(Error(ofile.of_filename, filename, "filename too long"));
-  if String.length extra >= 0x10000 then
-    raise(Error(ofile.of_filename, filename, "extra data too long"));
-  if String.length comment >= 0x10000 then
-    raise(Error(ofile.of_filename, filename, "comment too long"));
-  let oc = ofile.of_channel in
-  let pos = Out_channel.pos oc in
-  write4 oc (Int32.of_int 0x04034b50);  (* signature *)
-  let version = if level = 0 then 10 else 20 in
-  write2 oc version;                    (* version needed to extract *)
-  write2 oc 8;                          (* flags *)
-  write2 oc (if level = 0 then 0 else 8); (* method *)
-  let (time, date) = dostime_of_unixtime mtime in
-  write2 oc time;                       (* last mod time *)
-  write2 oc date;                       (* last mod date *)
-  write4 oc Int32.zero;                 (* CRC32 - to be filled later *)
-  write4_int oc 0;                      (* compressed size - later *)
-  write4_int oc 0;                      (* uncompressed size - later *)
-  write2 oc (String.length filename);   (* filename length *)
-  write2 oc (String.length extra);      (* extra length *)
-  writestring oc filename;              (* filename *)
-  writestring oc extra;                 (* extra info *)
-  { filename = filename;
-    extra = extra;
-    comment = comment;
-    methd = (if level = 0 then Stored else Deflated);
-    mtime = mtime;
-    crc = Int32.zero;
-    uncompressed_size = 0;
-    compressed_size = 0;
-    is_directory = filename_is_directory filename;
-    file_offset = pos }
+  let add_entry_header ofile extra comment level mtime filename =
+    if level < 0 || level > 9 then
+      raise(Error(ofile.of_filename, filename, "wrong compression level"));
+    if String.length filename >= 0x10000 then
+      raise(Error(ofile.of_filename, filename, "filename too long"));
+    if String.length extra >= 0x10000 then
+      raise(Error(ofile.of_filename, filename, "extra data too long"));
+    if String.length comment >= 0x10000 then
+      raise(Error(ofile.of_filename, filename, "comment too long"));
+    let oc = ofile.of_channel in
+    let pos = Out_channel.pos oc in
+    write4 oc (Int32.of_int 0x04034b50);  (* signature *)
+    let version = if level = 0 then 10 else 20 in
+    write2 oc version;                    (* version needed to extract *)
+    write2 oc 8;                          (* flags *)
+    write2 oc (if level = 0 then 0 else 8); (* method *)
+    let (time, date) = dostime_of_unixtime mtime in
+    write2 oc time;                       (* last mod time *)
+    write2 oc date;                       (* last mod date *)
+    write4 oc Int32.zero;                 (* CRC32 - to be filled later *)
+    write4_int oc 0;                      (* compressed size - later *)
+    write4_int oc 0;                      (* uncompressed size - later *)
+    write2 oc (String.length filename);   (* filename length *)
+    write2 oc (String.length extra);      (* extra length *)
+    writestring oc filename;              (* filename *)
+    writestring oc extra;                 (* extra info *)
+    { filename = filename;
+      extra = extra;
+      comment = comment;
+      methd = (if level = 0 then Stored else Deflated);
+      mtime = mtime;
+      crc = Int32.zero;
+      uncompressed_size = 0;
+      compressed_size = 0;
+      is_directory = filename_is_directory filename;
+      file_offset = pos }
 
-(* Write a data descriptor and update the entry *)
+  (* Write a data descriptor and update the entry *)
 
-let add_data_descriptor ofile crc compr_size uncompr_size entry =
-  let oc = ofile.of_channel in
-  write4 oc (Int32.of_int 0x08074b50);  (* signature *)
-  write4 oc crc;                        (* CRC *)
-  write4_int oc compr_size;             (* compressed size *)
-  write4_int oc uncompr_size;           (* uncompressed size *)
-  { entry with crc = crc;
-               uncompressed_size = uncompr_size;
-               compressed_size = compr_size }
+  let add_data_descriptor ofile crc compr_size uncompr_size entry =
+    let oc = ofile.of_channel in
+    write4 oc (Int32.of_int 0x08074b50);  (* signature *)
+    write4 oc crc;                        (* CRC *)
+    write4_int oc compr_size;             (* compressed size *)
+    write4_int oc uncompr_size;           (* uncompressed size *)
+    { entry with crc = crc;
+                 uncompressed_size = uncompr_size;
+                 compressed_size = compr_size }
 
-(* Add an entry with the contents of a string *)
+  (* Add an entry with the contents of a string *)
 
-let add_entry data ofile ?(extra = "") ?(comment = "")
-                         ?(level = 6) ?(mtime = Unix.time()) name =
-  let e = add_entry_header ofile extra comment level mtime name in
-  let crc = Zlib.update_crc_string Int32.zero data 0 (String.length data) in
-  let compr_size =
-    match level with
-      0 ->
-        Out_channel.output_substring ofile.of_channel data 0 (String.length data);
-        String.length data
-    | _ ->
-        let in_pos = ref 0 in
-        let out_pos = ref 0 in
-        try
-          Zlib.compress ~level ~header:false
-            (fun buf ->
-               let n = min (String.length data - !in_pos)
-                           (Bytes.length buf) in
-               String.blit data !in_pos buf 0 n;
-               in_pos := !in_pos + n;
-               n)
-            (fun buf n ->
-                Out_channel.output ofile.of_channel buf 0 n;
-                out_pos := !out_pos + n);
-          !out_pos
-        with Zlib.Error(_, _) ->
-          raise (Error(ofile.of_filename, name, "compression error")) in
-  let e' = add_data_descriptor ofile crc compr_size (String.length data) e in
-  ofile.of_entries <- e' :: ofile.of_entries
-
-(* Add an entry with the contents of an in channel *)
-
-let copy_channel_to_entry ic ofile ?(extra = "") ?(comment = "")
-                                   ?(level = 6) ?(mtime = Unix.time()) name =
-  let e = add_entry_header ofile extra comment level mtime name in
-  let crc = ref Int32.zero in
-  let (compr_size, uncompr_size) =
-    match level with
-      0 ->
-        let buf = Bytes.create 4096 in
-        let rec copy sz =
-          let r = input ic buf 0 (Bytes.length buf) in
-          if r = 0 then sz else begin
-            crc := Zlib.update_crc !crc buf 0 r;
-            Out_channel.output ofile.of_channel buf 0 r;
-            copy (sz + r)
-          end in
-        let size = copy 0 in
-        (size, size)
-    | _ ->
-        let in_pos = ref 0 in
-        let out_pos = ref 0 in
-        try
-          Zlib.compress ~level ~header:false
-            (fun buf ->
-               let r = input ic buf 0 (Bytes.length buf) in
-               crc := Zlib.update_crc !crc buf 0 r;
-               in_pos := !in_pos + r;
-               r)
-            (fun buf n ->
-               Out_channel.output ofile.of_channel buf 0 n;
-               out_pos := !out_pos + n);
-          (!out_pos, !in_pos)
-        with Zlib.Error(_, _) ->
-          raise (Error(ofile.of_filename, name, "compression error")) in
-  let e' = add_data_descriptor ofile !crc compr_size uncompr_size e in
-  ofile.of_entries <- e' :: ofile.of_entries
-
-(* Add an entry with the contents of a file *)
-
-let copy_file_to_entry infilename ofile ?(extra = "") ?(comment = "")
-                                        ?(level = 6) ?mtime name =
-  let ic = open_in_bin infilename in
-  let mtime' =
-    match mtime with
-      Some t -> mtime
-    | None ->
-        try Some((Unix.stat infilename).Unix.st_mtime)
-        with Unix.Unix_error(_,_,_) -> None in
-  try
-    copy_channel_to_entry ic ofile ~extra ~comment ~level ?mtime:mtime' name;
-    Stdlib.close_in ic
-  with x ->
-    Stdlib.close_in ic; raise x
-
-
-(* Add an entry whose content will be produced by the caller *)
-
-let add_entry_generator ofile ?(extra = "") ?(comment = "")
-                         ?(level = 6) ?(mtime = Unix.time()) name =
-  let e = add_entry_header ofile extra comment level mtime name in
-  let crc = ref Int32.zero in
-  let compr_size = ref 0 in
-  let uncompr_size = ref 0 in
-  let finished = ref false in
-  let check () =
-    if !finished then
-      raise (Error(ofile.of_filename, name, "entry already finished"))
-  in
-  let finish () =
-    finished := true;
-    let e' = add_data_descriptor ofile !crc !compr_size !uncompr_size e in
+  let add_entry data ofile ?(extra = "") ?(comment = "")
+                           ?(level = 6) ?(mtime = Unix.time()) name =
+    let e = add_entry_header ofile extra comment level mtime name in
+    let crc = Zlib.update_crc_string Int32.zero data 0 (String.length data) in
+    let compr_size =
+      match level with
+        0 ->
+          Out_channel.output_substring ofile.of_channel data 0 (String.length data);
+          String.length data
+      | _ ->
+          let in_pos = ref 0 in
+          let out_pos = ref 0 in
+          try
+            Zlib.compress ~level ~header:false
+              (fun buf ->
+                 let n = min (String.length data - !in_pos)
+                             (Bytes.length buf) in
+                 String.blit data !in_pos buf 0 n;
+                 in_pos := !in_pos + n;
+                 n)
+              (fun buf n ->
+                  Out_channel.output ofile.of_channel buf 0 n;
+                  out_pos := !out_pos + n);
+            !out_pos
+          with Zlib.Error(_, _) ->
+            raise (Error(ofile.of_filename, name, "compression error")) in
+    let e' = add_data_descriptor ofile crc compr_size (String.length data) e in
     ofile.of_entries <- e' :: ofile.of_entries
-  in
-  match level with
-  | 0 ->
-      (fun buf pos len ->
-        check ();
-        Out_channel.output ofile.of_channel buf pos len;
-        compr_size := !compr_size + len;
-        uncompr_size := !uncompr_size + len;
-        crc := Zlib.update_crc !crc buf pos len
-      ),
-      (fun () ->
-        check ();
-        finish ()
-      )
-  | _ ->
-      let (send, flush) = Zlib.compress_direct ~level ~header:false
-          (fun buf n ->
-            Out_channel.output ofile.of_channel buf 0 n;
-            compr_size := !compr_size + n)
-      in
-      (fun buf pos len ->
-        check ();
-        try
-          send buf pos len;
+
+  (* Add an entry with the contents of an in channel *)
+
+  let copy_channel_to_entry ic ofile ?(extra = "") ?(comment = "")
+                                     ?(level = 6) ?(mtime = Unix.time()) name =
+    let e = add_entry_header ofile extra comment level mtime name in
+    let crc = ref Int32.zero in
+    let (compr_size, uncompr_size) =
+      match level with
+        0 ->
+          let buf = Bytes.create 4096 in
+          let rec copy sz =
+            let r = input ic buf 0 (Bytes.length buf) in
+            if r = 0 then sz else begin
+              crc := Zlib.update_crc !crc buf 0 r;
+              Out_channel.output ofile.of_channel buf 0 r;
+              copy (sz + r)
+            end in
+          let size = copy 0 in
+          (size, size)
+      | _ ->
+          let in_pos = ref 0 in
+          let out_pos = ref 0 in
+          try
+            Zlib.compress ~level ~header:false
+              (fun buf ->
+                 let r = input ic buf 0 (Bytes.length buf) in
+                 crc := Zlib.update_crc !crc buf 0 r;
+                 in_pos := !in_pos + r;
+                 r)
+              (fun buf n ->
+                 Out_channel.output ofile.of_channel buf 0 n;
+                 out_pos := !out_pos + n);
+            (!out_pos, !in_pos)
+          with Zlib.Error(_, _) ->
+            raise (Error(ofile.of_filename, name, "compression error")) in
+    let e' = add_data_descriptor ofile !crc compr_size uncompr_size e in
+    ofile.of_entries <- e' :: ofile.of_entries
+
+  (* Add an entry with the contents of a file *)
+
+  let copy_file_to_entry infilename ofile ?(extra = "") ?(comment = "")
+                                          ?(level = 6) ?mtime name =
+    let ic = open_in_bin infilename in
+    let mtime' =
+      match mtime with
+        Some t -> mtime
+      | None ->
+          try Some((Unix.stat infilename).Unix.st_mtime)
+          with Unix.Unix_error(_,_,_) -> None in
+    try
+      copy_channel_to_entry ic ofile ~extra ~comment ~level ?mtime:mtime' name;
+      Stdlib.close_in ic
+    with x ->
+      Stdlib.close_in ic; raise x
+
+
+  (* Add an entry whose content will be produced by the caller *)
+
+  let add_entry_generator ofile ?(extra = "") ?(comment = "")
+                           ?(level = 6) ?(mtime = Unix.time()) name =
+    let e = add_entry_header ofile extra comment level mtime name in
+    let crc = ref Int32.zero in
+    let compr_size = ref 0 in
+    let uncompr_size = ref 0 in
+    let finished = ref false in
+    let check () =
+      if !finished then
+        raise (Error(ofile.of_filename, name, "entry already finished"))
+    in
+    let finish () =
+      finished := true;
+      let e' = add_data_descriptor ofile !crc !compr_size !uncompr_size e in
+      ofile.of_entries <- e' :: ofile.of_entries
+    in
+    match level with
+    | 0 ->
+        (fun buf pos len ->
+          check ();
+          Out_channel.output ofile.of_channel buf pos len;
+          compr_size := !compr_size + len;
           uncompr_size := !uncompr_size + len;
           crc := Zlib.update_crc !crc buf pos len
-        with Zlib.Error(_, _) ->
-          raise (Error(ofile.of_filename, name, "compression error"))
-      ),
-      (fun () ->
-        check ();
-        try
-          flush ();
+        ),
+        (fun () ->
+          check ();
           finish ()
-        with Zlib.Error(_, _) ->
-          raise (Error(ofile.of_filename, name, "compression error"))
-      )
+        )
+    | _ ->
+        let (send, flush) = Zlib.compress_direct ~level ~header:false
+            (fun buf n ->
+              Out_channel.output ofile.of_channel buf 0 n;
+              compr_size := !compr_size + n)
+        in
+        (fun buf pos len ->
+          check ();
+          try
+            send buf pos len;
+            uncompr_size := !uncompr_size + len;
+            crc := Zlib.update_crc !crc buf pos len
+          with Zlib.Error(_, _) ->
+            raise (Error(ofile.of_filename, name, "compression error"))
+        ),
+        (fun () ->
+          check ();
+          try
+            flush ();
+            finish ()
+          with Zlib.Error(_, _) ->
+            raise (Error(ofile.of_filename, name, "compression error"))
+        )
 end
 
 include Make_writer(struct

--- a/zlibstubs.c
+++ b/zlibstubs.c
@@ -69,11 +69,10 @@ value camlzip_deflateInit(value vlevel, value expect_header)
     caml_alloc_custom_mem(&camlzip_dstream_ops,
                           sizeof(z_streamp), sizeof(z_stream));
   ZStream_val(vzs) = caml_stat_alloc(sizeof(z_stream));
+  /* Zlib API: the fields zalloc, zfree and opaque must be initialized */
   ZStream_val(vzs)->zalloc = NULL;
   ZStream_val(vzs)->zfree = NULL;
   ZStream_val(vzs)->opaque = NULL;
-  ZStream_val(vzs)->next_in = NULL;
-  ZStream_val(vzs)->next_out = NULL;
   if (deflateInit2(ZStream_val(vzs),
                    Int_val(vlevel),
                    Z_DEFLATED,
@@ -142,12 +141,14 @@ value camlzip_inflateInit(value expect_header)
   value vzs =
     caml_alloc_custom_mem(&camlzip_istream_ops,
                           sizeof(z_streamp), sizeof(z_stream));
+  /* Zlib API: The fields next_in, avail_in, zalloc, zfree and opaque
+     must be initialized */
   ZStream_val(vzs) = caml_stat_alloc(sizeof(z_stream));
   ZStream_val(vzs)->zalloc = NULL;
   ZStream_val(vzs)->zfree = NULL;
   ZStream_val(vzs)->opaque = NULL;
   ZStream_val(vzs)->next_in = NULL;
-  ZStream_val(vzs)->next_out = NULL;
+  ZStream_val(vzs)->avail_in = 0;
   if (inflateInit2(ZStream_val(vzs),
                    Bool_val(expect_header) ? MAX_WBITS : -MAX_WBITS) != Z_OK)
     camlzip_error("Zlib.inflateInit", vzs);


### PR DESCRIPTION
This reapplies the 3 commits from oleksiy over a more recent upstream. Specifically, it incorporates https://github.com/xavierleroy/camlzip/pull/47 which fixes a memory leak.